### PR TITLE
Hotfix for frontend environment

### DIFF
--- a/frontend/src/environments/.env.dev
+++ b/frontend/src/environments/.env.dev
@@ -1,3 +1,3 @@
 VITE_ENV=dev
 # Enter backend url for development environment. For example: http://localhost:8080
-VITE_BACKEND_URL=""
+VITE_BACKEND_URL="http://localhost:8080"


### PR DESCRIPTION
This hotfix updates the `frontend/src/environments/.env.dev` file to correctly set the backend URL for the local development environment.

Previously, the `VITE_BACKEND_URL` variable was empty:

```env
VITE_ENV=dev
# Enter backend url for development environment. For example: http://localhost:8080
VITE_BACKEND_URL=""
```

The updated `.env.dev` now sets the URL to the local backend:

```env
VITE_ENV=dev
# Enter backend url for development environment. For example: http://localhost:8080
VITE_BACKEND_URL="http://localhost:8080"
```
