### PR TITLE
Added a call to populate OutboxEvent after new data is saved

### DIFF
--- a/backend/activities/presentation/viewsets.py
+++ b/backend/activities/presentation/viewsets.py
@@ -1,9 +1,11 @@
+from django.utils import timezone
 from rest_framework import viewsets
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAuthenticated
 
 from activities.business import ActivityService
 from activities.serializers import ActivitySerializer
+from activities.emit_event import emit_event
 from core.presentation import UserScopedCreateMixin
 
 
@@ -21,3 +23,20 @@ class ActivityViewSet(UserScopedCreateMixin, viewsets.ModelViewSet):
 
     def get_queryset(self):
         return self.service.get_user_queryset(self.request.user, self.request.query_params)
+
+    def perform_create(self, serializer):
+        activity = serializer.save(user=self.request.user)
+
+        # populate the OutboxEvent table;
+        # dispatcher reads the table
+        # and publishes to the queue to update the Analytics teams;
+        emit_event(
+            event_type="activity.imported",
+            payload={
+                "activity_id": str(activity.id),
+                "user_id": str(self.request.user.id),
+                "provider": activity.provider,
+                "timestamp": timezone.now().isoformat(),
+            },
+            idempotency_key=f"activity.imported:{activity.id}",
+        )

--- a/backend/core/presentation/mixins.py
+++ b/backend/core/presentation/mixins.py
@@ -5,18 +5,4 @@ class UserScopedCreateMixin:
     """Automatically assign the authenticated user on object creation."""
 
     def perform_create(self, serializer):
-        activity = serializer.save(user=self.request.user)
-
-        # populate the OutboxEvent table;
-        # dispatcher reads the table
-        # and publishes to the queue to update the Analytics teams;
-        emit_event(
-            event_type="activity.imported",
-            payload={
-                "activity_id": str(activity.id),
-                "user_id": str(self.request.user.id),
-                "provider": activity.provider,
-                "timestamp": timezone.now().isoformat(),
-            },
-            idempotency_key=f"activity.imported:{activity.id}",
-)
+        serializer.save(user=self.request.user)


### PR DESCRIPTION
I integrated the helper call into the correct viewset to ensure that each main save also creates a corresponding OutboxEvent record. Those records are later picked up by a dispatcher and enqueued to Celery for Analytics updates.