### PR TITLE
View Notifications endpoint

### DIFF
--- a/backend/notifications/presentation/views.py
+++ b/backend/notifications/presentation/views.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from notifications.business import NotificationService
-
+from notifications.business.services import NotificationService
 
 class NotificationsHealthView(APIView):
     permission_classes = [IsAuthenticated]
@@ -11,3 +11,14 @@ class NotificationsHealthView(APIView):
     def get(self, request):
         service = NotificationService()
         return Response({"recent_notifications": service.list_recent(request.user)})
+
+class ViewNotifications(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, user_id):
+        service = NotificationService()
+        notifications = service.get_all_notifications(user_id)
+
+        data = list(notifications.values())
+
+        return Response({"notifications": data})

--- a/backend/notifications/test_notifications.py
+++ b/backend/notifications/test_notifications.py
@@ -1,0 +1,21 @@
+import pytest
+from rest_framework.test import APIClient
+
+@pytest.mark.django_db
+def test_view_notifications_success():
+    client = APIClient()
+    response = client.get('/api/v1/notifications/1/')
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_view_notifications_empty():
+    client = APIClient()
+    response = client.get('/api/v1/notifications/9999/')
+    assert response.status_code == 200
+
+
+def test_unauthorized_access():
+    client = APIClient()
+    response = client.get('/api/v1/notifications/1/')
+    assert response.status_code in [401, 403]

--- a/backend/notifications/urls.py
+++ b/backend/notifications/urls.py
@@ -1,7 +1,10 @@
 from django.urls import path
 
 from .views import NotificationsHealthView
+from .views import ViewNotifications
+
 
 urlpatterns = [
     path("health/", NotificationsHealthView.as_view(), name="notifications_health"),
+    path('notifications/<int:user_id>/', ViewNotifications.as_view()),
 ]


### PR DESCRIPTION
Implemented View Notifications endpoint and test cases.

Includes:
- GET notifications by user
- Test cases (success, empty, unauthorized)