### PR TITLE
delete notification implementation

### DIFF
--- a/backend/notifications/presentation/views.py
+++ b/backend/notifications/presentation/views.py
@@ -1,6 +1,7 @@
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework import status
 
 from notifications.business import NotificationService
 
@@ -11,3 +12,26 @@ class NotificationsHealthView(APIView):
     def get(self, request):
         service = NotificationService()
         return Response({"recent_notifications": service.list_recent(request.user)})
+
+# --- YOUR FEATURE STARTS HERE ---
+class DeleteNotificationView(APIView):
+    permission_classes = [IsAuthenticated] 
+
+    def delete(self, request, notification_id):
+        service = NotificationService()
+        try:
+       
+            notification = service.get(notification_id)
+            
+            if not notification:
+                return Response({"error": "Notification not found"}, status=status.HTTP_404_NOT_FOUND) 
+
+            if notification.user.id != request.user.id:
+                return Response({"error": "Unauthorized deletion attempt"}, status=status.HTTP_403_FORBIDDEN) 
+
+        
+            service.delete(notification_id)
+            return Response(status=status.HTTP_204_NO_CONTENT) 
+            
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST) 

--- a/backend/notifications/urls.py
+++ b/backend/notifications/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-
-from .views import NotificationsHealthView
+from .views import NotificationsHealthView, DeleteNotificationView
 
 urlpatterns = [
     path("health/", NotificationsHealthView.as_view(), name="notifications_health"),
+
+    path("<int:notification_id>/delete/", DeleteNotificationView.as_view(), name="delete-notification"),
 ]


### PR DESCRIPTION
This PR implements the backend endpoint for the Delete Notification feature (Issue #159). It provides the necessary logic for users to remove notifications from their feed via a secure API call.