### PR TITLE
Mark Notification as Read endpoint - Issue #165

### DIFF
--- a/backend/notifications/presentation/views.py
+++ b/backend/notifications/presentation/views.py
@@ -22,3 +22,16 @@ class ViewNotifications(APIView):
         data = list(notifications.values())
 
         return Response({"notifications": data})
+
+class MarkNotificationAsRead(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def patch(self, request, notification_id):
+        service = NotificationService()
+        try:
+            notification = service.mark_as_read(notification_id)
+            return Response(
+                {"detail": "Notification marked as read.", "id": notification.id}
+            )
+        except Exception as e:
+            return Response({"error": str(e)}, status=404)

--- a/backend/notifications/urls.py
+++ b/backend/notifications/urls.py
@@ -2,9 +2,11 @@ from django.urls import path
 
 from .views import NotificationsHealthView
 from .views import ViewNotifications
+from .views import MarkNotificationAsRead
 
 
 urlpatterns = [
     path("health/", NotificationsHealthView.as_view(), name="notifications_health"),
     path('notifications/<int:user_id>/', ViewNotifications.as_view()),
+    path('notifications/<int:notification_id>/read/', MarkNotificationAsRead.as_view(), name="mark_notification_as_read"),
 ]


### PR DESCRIPTION
 Implements Mark Notification as Read endpoint.
   
   - Added MarkNotificationAsRead view in presentation/views.py
   - Added PATCH /api/v1/notifications/{id}/read/ route
   - Closes #165