### PR TITLE
Implement consumer/handler pattern for outbox events (Issue #117)

### DIFF
--- a/backend/core/backend/core/consumer.py
+++ b/backend/core/backend/core/consumer.py
@@ -1,0 +1,24 @@
+
+import logging
+from .handlers import EVENT_HANDLERS
+
+logger = logging.getLogger(__name__)
+
+
+def process_outbox_event(event):
+    handler = EVENT_HANDLERS.get(event.event_type)
+
+    if not handler:
+        logger.warning("No handler registered for event_type=%s", event.event_type)
+        print(f"[WARNING] No handler registered for event type: {event.event_type}")
+        return False
+
+    try:
+        handler(event.payload)
+        logger.info("Successfully processed event_id=%s type=%s", event.id, event.event_type)
+        print(f"[SUCCESS] Processed event_id={event.id} type={event.event_type}")
+        return True
+    except Exception as exc:
+        logger.exception("Failed processing event_id=%s: %s", event.id, exc)
+        print(f"[ERROR] Failed processing event_id={event.id}: {exc}")
+        return False

--- a/backend/core/backend/core/handlers.py
+++ b/backend/core/backend/core/handlers.py
@@ -1,0 +1,22 @@
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def handle_activity_imported(payload):
+    logger.info("Handling activity.imported for activity_id=%s", payload.get("activity_id"))
+    print(f"[HANDLER] activity.imported -> {payload}")
+    return {"status": "ok", "event": "activity.imported"}
+
+
+def handle_activity_updated(payload):
+    logger.info("Handling activity.updated for activity_id=%s", payload.get("activity_id"))
+    print(f"[HANDLER] activity.updated -> {payload}")
+    return {"status": "ok", "event": "activity.updated"}
+
+
+EVENT_HANDLERS = {
+    "activity.imported": handle_activity_imported,
+    "activity.updated": handle_activity_updated,
+}


### PR DESCRIPTION
Implements Issue #117 by adding a basic consumer/handler pattern for outbox events.

Changes:
- added backend/core/handlers.py
- added event handler mapping for activity.imported and activity.updated
- added logging for monitoring success, missing handlers, and failures

For other teams (analytics, goals, notifications):

You can subscribe to events by adding a handler function in handlers.py and registering it in the EVENT_HANDLERS dictionary.

Example:
- event_type: "activity.imported"
- payload fields: activity_id, user_id, provider, timestamp

This allows your background logic (analytics, achievements, etc.) to run automatically when new activities are saved.
