### PR TITLE
Feature: Request Authentication Validation #113

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'core.middleware.JWTAuthenticationMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -1,0 +1,64 @@
+import time
+import logging
+from django.http import JsonResponse
+
+logger = logging.getLogger(__name__)
+
+class JWTAuthenticationMiddleware:
+    """
+    Middleware that validates Bearer token format before
+    SimpleJWT processes the request.
+    Handles:
+      - Malformed Authorization header → 400
+      - Missing Bearer scheme → 400
+    Token validation (signature, expiry) is handled by SimpleJWT.
+    """
+
+    EXEMPT_PATHS = [
+        '/api/v1/auth/login/',
+        '/api/v1/auth/register/',
+        '/api/v1/auth/refresh/',
+        '/admin/',
+    ]
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        start_time = time.time()
+
+        # Skip validation for exempt paths
+        if any(request.path.startswith(path) for path in self.EXEMPT_PATHS):
+            return self.get_response(request)
+
+        auth_header = request.META.get('HTTP_AUTHORIZATION', '')
+
+        if auth_header:
+            # Validate format: must be "Bearer <token>"
+            parts = auth_header.split()
+
+            if len(parts) == 1:
+                return JsonResponse(
+                    {'error': 'Malformed Authorization header. Token missing after Bearer.'},
+                    status=400
+                )
+
+            if parts[0].lower() != 'bearer':
+                return JsonResponse(
+                    {'error': 'Invalid authentication scheme. Use Bearer token.'},
+                    status=400
+                )
+
+            if len(parts) > 2:
+                return JsonResponse(
+                    {'error': 'Malformed Authorization header. Too many parts.'},
+                    status=400
+                )
+
+        response = self.get_response(request)
+
+        # Log performance
+        duration_ms = (time.time() - start_time) * 1000
+        logger.debug(f"Auth middleware processed in {duration_ms:.2f}ms")
+
+        return response

--- a/backend/core/tests/test_middleware.py
+++ b/backend/core/tests/test_middleware.py
@@ -1,0 +1,84 @@
+import pytest
+from rest_framework.test import APIClient
+from rest_framework import status
+from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.tokens import RefreshToken
+
+User = get_user_model()
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+@pytest.fixture
+def create_user():
+    def _create_user(**kwargs):
+        defaults = {
+            'username': 'testuser',
+            'email': 'test@example.com',
+            'password': 'TestPass123!'
+        }
+        defaults.update(kwargs)
+        return User.objects.create_user(**defaults)
+    return _create_user
+
+@pytest.fixture
+def auth_token(create_user):
+    user = create_user()
+    refresh = RefreshToken.for_user(user)
+    return str(refresh.access_token)
+
+@pytest.mark.django_db
+class TestJWTAuthenticationMiddleware:
+
+    def test_valid_bearer_token_passes(self, api_client, auth_token):
+        """Valid Bearer token should pass through middleware"""
+        api_client.credentials(HTTP_AUTHORIZATION=f'Bearer {auth_token}')
+        response = api_client.get('/api/v1/activities/')
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_no_auth_header_passes_to_simplejwt(self, api_client):
+        """No auth header on protected endpoint — middleware passes, DRF returns 401"""
+        response = api_client.get('/api/v1/activities/')
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_malformed_header_missing_token(self, api_client):
+        """Authorization: Bearer with no token → 400"""
+        api_client.credentials(HTTP_AUTHORIZATION='Bearer')
+        response = api_client.get('/api/v1/activities/')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'error' in response.json()
+
+    def test_wrong_auth_scheme(self, api_client, auth_token):
+        """Authorization: Basic <token> → 400"""
+        api_client.credentials(HTTP_AUTHORIZATION=f'Basic {auth_token}')
+        response = api_client.get('/api/v1/activities/')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'error' in response.json()
+
+    def test_too_many_parts_in_header(self, api_client, auth_token):
+        """Authorization: Bearer <token> extra → 400"""
+        api_client.credentials(HTTP_AUTHORIZATION=f'Bearer {auth_token} extra')
+        response = api_client.get('/api/v1/activities/')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'error' in response.json()
+
+    def test_login_endpoint_is_exempt(self, api_client):
+        """Login endpoint should skip middleware validation"""
+        response = api_client.post('/api/v1/auth/login/', {
+            'username': 'nobody',
+            'password': 'wrongpass'
+        }, format='json')
+        # should get 401 from SimpleJWT, not 400 from middleware
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_register_endpoint_is_exempt(self, api_client):
+        """Register endpoint should skip middleware validation"""
+        response = api_client.post('/api/v1/auth/register/', {
+            'username': 'newuser',
+            'email': 'new@test.com',
+            'password': 'TestPass123!',
+            'password2': 'TestPass123!'
+        }, format='json')
+        # should get 201, not 400 from middleware
+        assert response.status_code == status.HTTP_201_CREATED


### PR DESCRIPTION
## Ticket #113 — JWT Authentication Middleware

### Summary
Implements a custom middleware layer that validates the format of the Authorization header on every incoming API request before it reaches SimpleJWT or any business logic. This ensures malformed requests are rejected early with clear, specific error messages.

---

### Changes

**`core/middleware.py`** (new file)
- Added `JWTAuthenticationMiddleware` class
- Validates that the Authorization header follows the `Bearer <token>` scheme
- Returns 400 Bad Request with a descriptive error message for malformed headers
- Exempt paths (login, register, refresh, admin) skip validation entirely
- Logs request processing time for performance monitoring

**`config/settings.py`**
- Registered `JWTAuthenticationMiddleware` as the first item in the `MIDDLEWARE` list so it runs before all other middleware

---

### How it works

```
Request comes in
  → JWTAuthenticationMiddleware   # checks header format only → 400 if malformed
  → SimpleJWT JWTAuthentication   # checks token validity → 401 if invalid/expired
  → View / business logic         # processes the request
```

The middleware handles three malformed header cases:

| Case | Example | Response |
|------|---------|----------|
| Missing token after Bearer | `Authorization: Bearer` | 400 Bad Request |
| Wrong auth scheme | `Authorization: Basic abc123` | 400 Bad Request |
| Too many parts | `Authorization: Bearer token1 token2` | 400 Bad Request |
| No header at all | — | Passed to SimpleJWT → 401 |
| Valid header | `Authorization: Bearer <token>` | Passed through |

---

### What this middleware does NOT do
Token signature validation, expiration checks, and attaching the user object to the request are all handled by SimpleJWT's `JWTAuthentication` class which is already configured globally via `DEFAULT_AUTHENTICATION_CLASSES` in settings. This middleware only validates the header format.

---

### Tests
**`core/tests/test_middleware.py`** (new file) — 7 tests, all passing
- `test_valid_bearer_token_passes` — valid token reaches the endpoint (200)
- `test_no_auth_header_passes_to_simplejwt` — no header passes through, SimpleJWT returns 401
- `test_malformed_header_missing_token` — Bearer with no token → 400
- `test_wrong_auth_scheme` — Basic scheme → 400
- `test_too_many_parts_in_header` — extra parts in header → 400
- `test_login_endpoint_is_exempt` — login skips middleware
- `test_register_endpoint_is_exempt` — register skips middleware

---

### Acceptance Criteria Checklist
- [x] Authentication validation occurs in middleware layer
- [x] Bearer token format is enforced in Authorization header
- [x] Token validation (signature, expiry) handled by SimpleJWT
- [x] User object attached to request context by SimpleJWT
- [x] Validation failure immediately halts request processing
- [x] Returns 400 for malformed Authorization header
- [x] Returns 401 for missing or invalid token (via SimpleJWT)
- [x] Exempt paths (login, register, refresh, admin) bypass middleware
- [x] Performance logging included for monitoring

---

### Notes
- Middleware is placed in `core/` since authentication is a shared concern across all apps
- SimpleJWT's `JWTAuthentication` was already globally configured — this middleware complements it without replacing any existing behaviour
- Exempt paths can be extended in `JWTAuthenticationMiddleware.EXEMPT_PATHS` if new public endpoints are added in the future