### PR TITLE
Fix: Add missing containerName parameter in backend deployment workflow

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -41,6 +41,7 @@ jobs:
           registryUsername: ${{ secrets.BACKEND_REGISTRY_USERNAME }}
           registryPassword: ${{ secrets.BACKEND_REGISTRY_PASSWORD }}
           containerAppName: backend
+          containerName: backend
           resourceGroup: habit-tracker-rg
           imageToBuild: habitregistry.azurecr.io/backend:${{ github.sha }}
           _buildArgumentsKey_: |


### PR DESCRIPTION
This pull request introduces a small change to the backend deployment workflow. The change specifies the `containerName` as `backend` in the `.github/workflows/backend-cd.yml` file, which helps ensure the deployment step targets the correct container.