### PR TITLE
G10 Feature: Create worker thread that queues pending outbox rows

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/backend/config/celery.py
+++ b/backend/config/celery.py
@@ -1,0 +1,9 @@
+import os
+
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+app = Celery("habit_tracker")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -182,3 +182,13 @@ STATIC_URL = 'static/'
 
 STRAVA_CLIENT_ID = os.environ.get('STRAVA_CLIENT_ID')
 STRAVA_CLIENT_SECRET = os.environ.get('STRAVA_CLIENT_SECRET')
+
+# Celery
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://redis:6379/0")
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", "redis://redis:6379/0")
+CELERY_BEAT_SCHEDULE = {
+    "process-pending-outbox-events": {
+        "task": "core.tasks.process_pending_outbox_events",
+        "schedule": 10.0,  # seconds
+    },
+}

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -1,0 +1,63 @@
+"""
+core/tasks.py
+
+Outbox worker: polls outbox_events for PENDING rows, dispatches them via
+process_outbox_event(), and marks each row PUBLISHED or FAILED.
+
+Runs on a schedule via Celery Beat (configured in settings.py).
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from celery import shared_task
+
+from core.consumer import process_outbox_event
+from core.models import OutboxEvent
+
+logger = logging.getLogger(__name__)
+
+MAX_RETRIES = 3
+
+
+@shared_task(name="core.tasks.process_pending_outbox_events")
+def process_pending_outbox_events() -> None:
+    """Poll outbox_events for PENDING rows and dispatch each one."""
+    pending = OutboxEvent.objects.filter(status=OutboxEvent.Status.PENDING).order_by("created_at")
+
+    if not pending.exists():
+        logger.debug("No PENDING outbox events found.")
+        return
+
+    for event in pending:
+        _dispatch_event(event)
+
+
+def _dispatch_event(event: OutboxEvent) -> None:
+    event.attempts += 1
+    try:
+        success = process_outbox_event(event)
+        if not success:
+            raise RuntimeError(f"process_outbox_event returned False for event_type={event.event_type}")
+        event.status = OutboxEvent.Status.PUBLISHED
+        event.published_at = datetime.now(tz=timezone.utc)
+        event.last_error = None
+        logger.info(
+            "OutboxEvent published: id=%s event_type=%s attempts=%s",
+            event.event_id, event.event_type, event.attempts,
+        )
+    except Exception as exc:  # noqa: BLE001
+        event.last_error = str(exc)
+        if event.attempts >= MAX_RETRIES:
+            event.status = OutboxEvent.Status.FAILED
+            logger.error(
+                "OutboxEvent FAILED after %s attempts: id=%s event_type=%s error=%s",
+                event.attempts, event.event_id, event.event_type, exc,
+            )
+        else:
+            logger.warning(
+                "OutboxEvent dispatch error (attempt %s/%s): id=%s event_type=%s error=%s",
+                event.attempts, MAX_RETRIES, event.event_id, event.event_type, exc,
+            )
+    finally:
+        event.save(update_fields=["status", "attempts", "last_error", "published_at"])

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 
 from celery import shared_task
 
-from core.consumer import process_outbox_event
+from core.backend.core.consumer import process_outbox_event
 from core.models import OutboxEvent
 
 logger = logging.getLogger(__name__)

--- a/backend/core/tests/test_outbox_worker.py
+++ b/backend/core/tests/test_outbox_worker.py
@@ -1,0 +1,119 @@
+from unittest.mock import patch
+
+import pytest
+
+from core.models import OutboxEvent
+from core.tasks import MAX_RETRIES, process_pending_outbox_events
+
+DUMMY_PAYLOAD = {
+    "activity_id": 1,
+    "user_id": 1,
+    "provider": "strava",
+    "timestamp": "2026-04-20T00:00:00Z",
+}
+
+
+def make_event(**kwargs):
+    defaults = dict(
+        event_type="activity.imported",
+        payload=DUMMY_PAYLOAD,
+        status=OutboxEvent.Status.PENDING,
+    )
+    defaults.update(kwargs)
+    return OutboxEvent.objects.create(**defaults)
+
+
+@pytest.mark.django_db
+class TestProcessPendingOutboxEvents:
+
+    def test_no_pending_events_does_nothing(self):
+        """Task runs without error when there are no PENDING rows."""
+        with patch("core.tasks.process_outbox_event") as mock_process:
+            process_pending_outbox_events()
+            mock_process.assert_not_called()
+
+    def test_published_and_failed_events_are_skipped(self):
+        """Only PENDING rows are picked up; other statuses are ignored."""
+        make_event(status=OutboxEvent.Status.PUBLISHED)
+        make_event(status=OutboxEvent.Status.FAILED)
+
+        with patch("core.tasks.process_outbox_event") as mock_process:
+            process_pending_outbox_events()
+            mock_process.assert_not_called()
+
+    def test_successful_event_marked_published(self):
+        """A PENDING event that dispatches successfully is marked PUBLISHED."""
+        event = make_event()
+
+        with patch("core.tasks.process_outbox_event", return_value=True):
+            process_pending_outbox_events()
+
+        event.refresh_from_db()
+        assert event.status == OutboxEvent.Status.PUBLISHED
+        assert event.attempts == 1
+        assert event.published_at is not None
+        assert event.last_error is None
+
+    def test_failed_event_below_max_retries_stays_pending(self):
+        """A dispatch failure below MAX_RETRIES leaves the event PENDING for retry."""
+        event = make_event()
+
+        with patch("core.tasks.process_outbox_event", return_value=False):
+            process_pending_outbox_events()
+
+        event.refresh_from_db()
+        assert event.status == OutboxEvent.Status.PENDING
+        assert event.attempts == 1
+        assert event.last_error is not None
+
+    def test_event_marked_failed_after_max_retries(self):
+        """An event that has already failed MAX_RETRIES-1 times is marked FAILED on next failure."""
+        event = make_event(attempts=MAX_RETRIES - 1)
+
+        with patch("core.tasks.process_outbox_event", return_value=False):
+            process_pending_outbox_events()
+
+        event.refresh_from_db()
+        assert event.status == OutboxEvent.Status.FAILED
+        assert event.attempts == MAX_RETRIES
+
+    def test_exception_from_handler_treated_as_failure(self):
+        """An exception raised inside process_outbox_event is caught and counted as a failure."""
+        event = make_event()
+
+        with patch("core.tasks.process_outbox_event", side_effect=RuntimeError("boom")):
+            process_pending_outbox_events()
+
+        event.refresh_from_db()
+        assert event.status == OutboxEvent.Status.PENDING
+        assert event.attempts == 1
+        assert "boom" in event.last_error
+
+    def test_multiple_pending_events_all_processed(self):
+        """All PENDING rows are dispatched in a single task run."""
+        events = [make_event() for _ in range(3)]
+
+        with patch("core.tasks.process_outbox_event", return_value=True):
+            process_pending_outbox_events()
+
+        for event in events:
+            event.refresh_from_db()
+            assert event.status == OutboxEvent.Status.PUBLISHED
+
+    def test_one_failure_does_not_block_others(self):
+        """A failure on one event does not prevent subsequent events from being processed."""
+        failing = make_event(event_type="activity.imported")
+        succeeding = make_event(event_type="activity.updated")
+
+        def side_effect(event):
+            if event.pk == failing.pk:
+                return False
+            return True
+
+        with patch("core.tasks.process_outbox_event", side_effect=side_effect):
+            process_pending_outbox_events()
+
+        failing.refresh_from_db()
+        succeeding.refresh_from_db()
+        assert failing.status == OutboxEvent.Status.PENDING
+        assert succeeding.status == OutboxEvent.Status.PUBLISHED

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -35,5 +35,26 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+
+  celery-beat:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: celery -A config beat --loglevel=info
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    volumes:
+      - .:/app
+
 volumes:
   postgres_data:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,6 @@
 asgiref==3.11.1
+celery==5.4.0
+redis==5.2.1
 Django==6.0.2
 django-allauth==65.14.3
 djangorestframework==3.16.1


### PR DESCRIPTION
Resolves issue #125 
Passes tests in core/tests/outbox_worker_test.py

Touches a few files outside of the scope of our group, as additional dependencies were required (Celery, Redis)