### PR TITLE
Implement logout token revocation for issue #102

### DIFF
--- a/backend/users/presentation/views.py
+++ b/backend/users/presentation/views.py
@@ -1,8 +1,10 @@
 from django.contrib.auth import get_user_model
 from rest_framework import generics
 from rest_framework.permissions import AllowAny, IsAuthenticated
-
-from users.serializers import RegisterSerializer, ProfileUpdateSerializer
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from users.serializers import RegisterSerializer, ProfileUpdateSerializer, LogoutSerializer
 
 User = get_user_model()
 
@@ -25,3 +27,12 @@ class ProfileUpdateView(generics.RetrieveUpdateAPIView):
         # Requirement: Users can only update their own profile.
         # This returns the user associated with the JWT token.
         return self.request.user
+
+class LogoutView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def post(self, request):
+        serializer = LogoutSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response({"message": "Logout successful"}, status=status.HTTP_200_OK)

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -2,10 +2,22 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password
 from rest_framework import serializers
 from django.contrib.auth.hashers import check_password
+from rest_framework_simplejwt.tokens import RefreshToken, TokenError
+
 
 from users.business import UserRegistrationService
 
 User = get_user_model()
+
+class LogoutSerializer(serializers.Serializer):
+    refresh = serializers.CharField()
+
+    def save(self, **kwargs):
+        try:
+            token = RefreshToken(self.validated_data["refresh"])
+            token.blacklist()
+        except TokenError:
+            raise serializers.ValidationError("Invalid or expired refresh token")
 
 
 class RegisterSerializer(serializers.ModelSerializer):

--- a/backend/users/tests/test_auth.py
+++ b/backend/users/tests/test_auth.py
@@ -2,6 +2,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
 from rest_framework import status
+from rest_framework_simplejwt.tokens import RefreshToken
 
 User = get_user_model()
 
@@ -89,3 +90,69 @@ class TestAuthentication:
         refresh_response = api_client.post('/api/v1/auth/refresh/', refresh_data, format='json')
         assert refresh_response.status_code == status.HTTP_200_OK
         assert 'access' in refresh_response.data
+    def test_logout_success(self, api_client, create_user):
+            """Test successful logout blacklists refresh token"""
+            user = create_user()
+            refresh = RefreshToken.for_user(user)
+            access_token = str(refresh.access_token)
+
+            api_client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+            response = api_client.post(
+                '/api/v1/auth/logout/',
+                {'refresh': str(refresh)},
+                format='json'
+            )
+
+            assert response.status_code == status.HTTP_200_OK
+            assert response.data['message'] == 'Logout successful'
+
+    def test_logout_requires_authentication(self, api_client, create_user):
+        """Test logout fails without access token"""
+        user = create_user()
+        refresh = RefreshToken.for_user(user)
+
+        response = api_client.post(
+            '/api/v1/auth/logout/',
+            {'refresh': str(refresh)},
+            format='json'
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_logout_with_invalid_refresh_token_fails(self, api_client, create_user):
+        """Test logout fails with invalid refresh token"""
+        user = create_user()
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        api_client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+        response = api_client.post(
+            '/api/v1/auth/logout/',
+            {'refresh': 'invalid-token'},
+            format='json'
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_blacklisted_refresh_token_cannot_be_reused(self, api_client, create_user):
+        """Test blacklisted refresh token cannot be used again"""
+        user = create_user()
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        api_client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        logout_response = api_client.post(
+            '/api/v1/auth/logout/',
+            {'refresh': str(refresh)},
+            format='json'
+        )
+        assert logout_response.status_code == status.HTTP_200_OK
+
+        reuse_response = api_client.post(
+            '/api/v1/auth/refresh/',
+            {'refresh': str(refresh)},
+            format='json'
+        )
+
+        assert reuse_response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -4,11 +4,12 @@ from rest_framework_simplejwt.views import (
     TokenRefreshView,
 )
 
-from .views import RegisterView, ProfileUpdateView
+from .views import RegisterView, ProfileUpdateView, LogoutView
 
 urlpatterns = [
     path('register/', RegisterView.as_view(), name='auth_register'),
     path('login/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('profile/', ProfileUpdateView.as_view(), name='profile_update'),
+    path('logout/', LogoutView.as_view(), name='auth_logout')
 ]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,3 +1,3 @@
-from users.presentation.views import RegisterView, ProfileUpdateView
+from users.presentation.views import RegisterView, ProfileUpdateView, LogoutView
 
-__all__ = ["RegisterView", "ProfileUpdateView"]
+__all__ = ["RegisterView", "ProfileUpdateView", "LogoutView"]


### PR DESCRIPTION
Implemented Issue #102: revoke token when logging out.

Changes:
- Added logout endpoint at /api/v1/auth/logout/
- Blacklists refresh token on logout
- Added LogoutSerializer
- Added tests for:
  - successful logout
  - missing authentication
  - invalid refresh token
  - blacklisted token reuse prevention