### PR TITLE
#175 Created Dashboard E2E tests

### DIFF
--- a/frontend/cypress/e2e/navigation.cy.ts
+++ b/frontend/cypress/e2e/navigation.cy.ts
@@ -13,15 +13,43 @@ describe('Navigation flows', () => {
     cy.contains('Get started').click();
     cy.url().should('include', '/app');
     cy.contains('Dashboard').should('be.visible');
-    cy.contains('Welcome back! Use the navigation to manage your habits.').should('be.visible');
-    cy.contains('Habits').should('be.visible');
-    cy.contains('Profile').should('be.visible');
+    cy.contains(
+      'Welcome back! Use the navigation to manage your habits.',
+    ).should('be.visible');
   });
 
+  it('renders dashboard content on direct /app visit', () => {
+    cy.visit('/app');
+
+    cy.contains('Dashboard').should('be.visible');
+    cy.contains(
+      'Welcome back! Use the navigation to manage your habits.',
+    ).should('be.visible');
+  });
+
+  it('keeps app navigation usable after direct /app visit', () => {
+    cy.intercept('GET', '**/habits', {
+      statusCode: 200,
+      body: [],
+    }).as('getHabits');
+
+    cy.visit('/app');
+
+    cy.contains('Habits').click();
+    cy.url().should('include', '/app/habits');
+    cy.wait('@getHabits');
+    cy.contains('My Habits').should('be.visible');
+
+    cy.contains('Profile').click();
+    cy.url().should('include', '/app/profile');
+    cy.contains('Profile').should('be.visible');
+    cy.contains('Manage your account settings here.').should('be.visible');
+  });
+  
   it('shows 404 page for unknown route and can go back home', () => {
-  cy.visit('/does-not-exist', { failOnStatusCode: false });
-  cy.contains('404').should('be.visible');
-  cy.contains('Go home').click();
-  cy.url().should('eq', Cypress.config().baseUrl + '/');
-});
+    cy.visit('/does-not-exist', { failOnStatusCode: false });
+    cy.contains('404').should('be.visible');
+    cy.contains('Go home').click();
+    cy.url().should('eq', Cypress.config().baseUrl + '/');
+  });
 });


### PR DESCRIPTION
### Summary
This PR expands Cypress coverage for the dashboard flow in the frontend app.

### What’s included
- Verifies the dashboard page renders its heading and welcome copy on direct visit to /app
- Verifies the landing page 'Get started' CTA routes users to the dashboard
- Verifies app navigation remains usable after directly loading /app (e.g., navigating to Habits and Profile)
- Verifies 404 page is shown for unknown routes and that users can navigate back to the home page
