### PR TITLE
Implementation of a backup and restore scripts for the database

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -27,6 +27,7 @@ media/
 
 # Database artifacts (local/dev)
 *.sqlite3
+backups/
 
 # OS/editor noise
 .DS_Store

--- a/backend/README.md
+++ b/backend/README.md
@@ -109,6 +109,35 @@ docker compose logs -f api
 docker compose down
 ```
 
+## Database - Backup and Restore
+- Backup location: `backend/backups`
+
+Prerequisites:
+- docker container needs to be running
+- `.env` needs to be created and filled
+
+### Backup
+```bash
+./scripts/db-backup.sh <opt: filepath>
+```
+
+- Exports the database to a backup file.
+- Default filename is `db_timestamp.dump`.
+
+### Restore 
+```bash
+./scripts/db-restore.sh <backup_file>
+```
+
+- Restores the database from a backup file. 
+- All existing data will be overwritten.
+
+### Automation
+cron daily at 02:00:
+```bash
+0 2 * * * cd ~/habit-tracker-monorepo/backend && /usr/bin/env bash scripts/db-backup-latest.sh
+```
+
 ## API Namespaces
 
 All endpoints are under `/api/v1/`.

--- a/backend/scripts/db-backup.sh
+++ b/backend/scripts/db-backup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKUP_DIR="$ROOT_DIR/backups"
+TIMESTAMP="$(date +"%Y%m%d_%H%M%S")"
+BACKUP_FILE="${1:-$BACKUP_DIR/habit_tracker_${TIMESTAMP}.dump}"
+
+# load env vars
+if [[ -f "$ROOT_DIR/.env" ]]; then
+  set -a
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+# fail if required env vars are missing
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+
+mkdir -p "$(dirname "$BACKUP_FILE")"
+
+cd "$ROOT_DIR"
+
+echo "Creating PostgreSQL backup: $BACKUP_FILE"
+docker compose exec -T postgres pg_dump \
+  -U "$POSTGRES_USER" \
+  -d "$POSTGRES_DB" \
+  -Fc \
+  --no-owner \
+  --no-privileges > "$BACKUP_FILE"
+
+if [[ ! -s "$BACKUP_FILE" ]]; then
+  echo "Backup failed: file is empty"
+  exit 1
+fi
+
+echo "Backup created successfully: $BACKUP_FILE"

--- a/backend/scripts/db-restore.sh
+++ b/backend/scripts/db-restore.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <backup_file.dump>"
+  exit 1
+fi
+
+BACKUP_FILE="$1"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# load env vars
+if [[ -f "$ROOT_DIR/.env" ]]; then
+  set -a
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+# fail if required env vars are missing
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+
+if [[ ! -f "$BACKUP_FILE" ]]; then
+  echo "Backup file not found: $BACKUP_FILE"
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+echo "Restoring PostgreSQL backup from: $BACKUP_FILE"
+docker compose exec -T postgres pg_restore \
+  -U "$POSTGRES_USER" \
+  -d "$POSTGRES_DB" \
+  --clean \
+  --if-exists \
+  --no-owner \
+  --no-privileges < "$BACKUP_FILE"
+
+echo "Restore completed successfully."


### PR DESCRIPTION
This pull request adds automated database backup and restore functionality to the backend, along with documentation and supporting scripts. The main changes include new scripts for backing up and restoring the PostgreSQL database, updates to documentation, and adjustments to the `.gitignore` to manage backup files.

**Database backup and restore functionality:**

* Added `db-backup.sh` script to automate exporting the PostgreSQL database to a backup file in the `backups/` directory, with support for custom filenames and environment variable loading.
* Added `db-restore.sh` script to restore the database from a specified backup file, including environment variable handling and safety checks.
* Updated `.gitignore` to exclude the `backups/` directory from version control, preventing backup files from being tracked.

**Documentation updates:**

* Updated `README.md` with detailed instructions for backing up and restoring the database, prerequisites, usage examples for the new scripts, and an example cron job for automated daily backups.

Closes #140.