### PR TITLE
feat: Google OAuth Login (#83)

### DIFF
--- a/backend/users/business/services.py
+++ b/backend/users/business/services.py
@@ -3,6 +3,9 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework import status
 from rest_framework.exceptions import APIException
 import logging
+import requests
+from urllib.parse import urlencode
+from django.conf import settings
 
 from core.business import BaseService
 from users.data import UserRepository
@@ -82,3 +85,79 @@ class AccountDeletionService(BaseService):
             user.id,
             user.username,
         )
+
+class OAuthService(BaseService):
+    """Handles Google OAuth login flow: auth URL generation + callback handling."""
+
+    GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+    GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+    GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
+
+    def __init__(self, repository=None):
+        self.repository = repository or UserRepository()
+
+    def get_google_auth_url(self):
+        """Build the URL that redirects users to Google's sign-in page."""
+        params = {
+            "client_id": settings.GOOGLE_CLIENT_ID,
+            "redirect_uri": settings.GOOGLE_REDIRECT_URI,
+            "response_type": "code",
+            "scope": "openid email profile",
+            "access_type": "offline",
+            "prompt": "consent",
+        }
+        return f"{self.GOOGLE_AUTH_URL}?{urlencode(params)}"
+
+    def handle_google_callback(self, code):
+        """
+        Exchange the authorization code for user info,
+        then create or link a user account.
+        Returns the User object.
+        """
+        if not code:
+            raise ValueError("Missing authorization code")
+
+        token_data = self._exchange_code(code)
+        access_token = token_data.get("access_token")
+        if not access_token:
+            raise ValueError("Invalid or expired authorization code")
+
+        user_info = self._get_user_info(access_token)
+
+        user = self.repository.get_or_create_oauth_user(
+            provider="google",
+            provider_id=user_info["id"],
+            email=user_info["email"],
+            first_name=user_info.get("given_name", ""),
+            last_name=user_info.get("family_name", ""),
+        )
+        logger.info("OAuth login successful: user_id=%s, email=%s", user.id, user.email)
+        return user
+
+    def _exchange_code(self, code):
+        """Exchange the authorization code for an access token from Google."""
+        response = requests.post(
+            self.GOOGLE_TOKEN_URL,
+            data={
+                "code": code,
+                "client_id": settings.GOOGLE_CLIENT_ID,
+                "client_secret": settings.GOOGLE_CLIENT_SECRET,
+                "redirect_uri": settings.GOOGLE_REDIRECT_URI,
+                "grant_type": "authorization_code",
+            },
+            timeout=10,
+        )
+        if response.status_code != 200:
+            raise ValueError("Invalid or expired authorization code")
+        return response.json()
+
+    def _get_user_info(self, access_token):
+        """Fetch the user's Google profile information using the access token."""
+        response = requests.get(
+            self.GOOGLE_USERINFO_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10,
+        )
+        if response.status_code != 200:
+            raise ValueError("Failed to retrieve user information")
+        return response.json()

--- a/backend/users/data/repositories.py
+++ b/backend/users/data/repositories.py
@@ -30,3 +30,41 @@ class UserRepository(BaseRepository):
     def lock_account(self, user):
         user.locked_until = timezone.now() + timezone.timedelta(minutes=30)
         user.save(update_fields=['locked_until'])
+
+    def get_or_create_oauth_user(self, provider, provider_id, email, first_name="", last_name=""):
+        try:
+            user = self.model.objects.get(
+                oauth_provider=provider,
+                oauth_provider_id=provider_id,
+            )
+            return user
+        except self.model.DoesNotExist:
+            pass
+
+        try:
+            user = self.model.objects.get(email=email)
+            user.oauth_provider = provider
+            user.oauth_provider_id = provider_id
+            user.save(update_fields=["oauth_provider", "oauth_provider_id"])
+            return user
+        except self.model.DoesNotExist:
+            pass
+
+        username = email.split("@")[0]
+        base_username = username
+        counter = 1
+        while self.model.objects.filter(username=username).exists():
+            username = f"{base_username}{counter}"
+            counter += 1
+
+        user = self.model.objects.create(
+            username=username,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            oauth_provider=provider,
+            oauth_provider_id=provider_id,
+        )
+        user.set_unusable_password()
+        user.save()
+        return user

--- a/backend/users/presentation/views.py
+++ b/backend/users/presentation/views.py
@@ -2,13 +2,16 @@ from django.contrib.auth import get_user_model
 from rest_framework import generics
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.views import APIView
 from rest_framework_simplejwt.views import TokenObtainPairView
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 from rest_framework.exceptions import AuthenticationFailed
 
 
 from users.serializers import RegisterSerializer, ProfileUpdateSerializer
-from users.business.services import UserRegistrationService
+from users.business.services import UserRegistrationService, OAuthService
+from rest_framework_simplejwt.tokens import RefreshToken
 
 User = get_user_model()
 
@@ -55,3 +58,41 @@ class CustomTokenObtainPairView(TokenObtainPairView):
         except (InvalidToken, TokenError, AuthenticationFailed):  # added AuthenticationFailed
             self.service.record_failed_attempt(username)
             raise
+
+class GoogleAuthURLView(APIView):
+    """
+    GET /api/v1/auth/oauth/google/
+    Returns the Google authorization URL the frontend should redirect users to.
+    """
+    permission_classes = (AllowAny,)
+
+    def get(self, request):
+        service = OAuthService()
+        auth_url = service.get_google_auth_url()
+        return Response({"authorization_url": auth_url}, status=status.HTTP_200_OK)
+
+
+class GoogleCallbackView(APIView):
+    permission_classes = (AllowAny,)
+
+    def get(self, request):
+        code = request.query_params.get("code")
+        if not code:
+            return Response(
+                {"error": "Missing authorization code"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            service = OAuthService()
+            user = service.handle_google_callback(code)
+        except ValueError as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        refresh = RefreshToken.for_user(user)
+        return Response(
+            {
+                "access": str(refresh.access_token),
+                "refresh": str(refresh),
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/backend/users/tests/test_oauth.py
+++ b/backend/users/tests/test_oauth.py
@@ -1,0 +1,102 @@
+import pytest
+from unittest.mock import patch
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.mark.django_db
+class TestGoogleOAuth:
+    """Tests for the Google OAuth login feature (issue #83)."""
+
+    def test_get_google_auth_url(self, api_client, settings):
+        """GET /api/v1/auth/oauth/google/ returns a valid Google authorization URL."""
+        settings.GOOGLE_CLIENT_ID = "test-client-id"
+        settings.GOOGLE_REDIRECT_URI = "http://localhost/callback/"
+
+        response = api_client.get("/api/v1/auth/oauth/google/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "authorization_url" in response.data
+        assert "accounts.google.com" in response.data["authorization_url"]
+        assert "test-client-id" in response.data["authorization_url"]
+
+    def test_callback_missing_code_returns_400(self, api_client):
+        """GET /callback/ without a code query param returns 400."""
+        response = api_client.get("/api/v1/auth/oauth/google/callback/")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch("users.business.services.OAuthService._get_user_info")
+    @patch("users.business.services.OAuthService._exchange_code")
+    def test_callback_creates_new_user(self, mock_exchange, mock_userinfo, api_client, settings):
+        """A valid OAuth code for a brand-new user creates the account and returns JWTs."""
+        settings.GOOGLE_CLIENT_ID = "test-client-id"
+        settings.GOOGLE_CLIENT_SECRET = "test-secret"
+        settings.GOOGLE_REDIRECT_URI = "http://localhost/callback/"
+
+        mock_exchange.return_value = {"access_token": "fake-token"}
+        mock_userinfo.return_value = {
+            "id": "google-user-id-123",
+            "email": "newuser@gmail.com",
+            "given_name": "New",
+            "family_name": "User",
+        }
+
+        response = api_client.get("/api/v1/auth/oauth/google/callback/?code=fake-code")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "access" in response.data
+        assert "refresh" in response.data
+
+        user = User.objects.get(email="newuser@gmail.com")
+        assert user.oauth_provider == "google"
+        assert user.oauth_provider_id == "google-user-id-123"
+        assert not user.has_usable_password()  # OAuth user should have no password
+
+    @patch("users.business.services.OAuthService._get_user_info")
+    @patch("users.business.services.OAuthService._exchange_code")
+    def test_callback_links_existing_user(self, mock_exchange, mock_userinfo, api_client, settings):
+        """A valid OAuth code matching an existing user's email links the account."""
+        settings.GOOGLE_CLIENT_ID = "test-client-id"
+        settings.GOOGLE_CLIENT_SECRET = "test-secret"
+        settings.GOOGLE_REDIRECT_URI = "http://localhost/callback/"
+
+        existing_user = User.objects.create_user(
+            username="existing",
+            email="existing@gmail.com",
+            password="TestPass123!",
+        )
+
+        mock_exchange.return_value = {"access_token": "fake-token"}
+        mock_userinfo.return_value = {
+            "id": "google-user-id-456",
+            "email": "existing@gmail.com",
+            "given_name": "Existing",
+            "family_name": "User",
+        }
+
+        response = api_client.get("/api/v1/auth/oauth/google/callback/?code=fake-code")
+
+        assert response.status_code == status.HTTP_200_OK
+        existing_user.refresh_from_db()
+        assert existing_user.oauth_provider == "google"
+        assert existing_user.oauth_provider_id == "google-user-id-456"
+
+    @patch("users.business.services.OAuthService._exchange_code")
+    def test_callback_invalid_code_returns_400(self, mock_exchange, api_client, settings):
+        """An invalid/expired authorization code returns 400."""
+        settings.GOOGLE_CLIENT_ID = "test-client-id"
+        settings.GOOGLE_CLIENT_SECRET = "test-secret"
+        settings.GOOGLE_REDIRECT_URI = "http://localhost/callback/"
+
+        mock_exchange.side_effect = ValueError("Invalid or expired authorization code")
+
+        response = api_client.get("/api/v1/auth/oauth/google/callback/?code=bad-code")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenRefreshView
 from .views import RegisterView, ProfileUpdateView
-from .presentation.views import CustomTokenObtainPairView
-
+from .presentation.views import CustomTokenObtainPairView, GoogleAuthURLView, GoogleCallbackView
 urlpatterns = [
     path('register/', RegisterView.as_view(), name='auth_register'),
     path('login/', CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),  # swapped
     path('refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('profile/', ProfileUpdateView.as_view(), name='profile_update'),
+    path('oauth/google/', GoogleAuthURLView.as_view(), name='google_auth_url'),
+    path('oauth/google/callback/', GoogleCallbackView.as_view(), name='google_callback'),
 ]


### PR DESCRIPTION
Closes #83

## What this PR does
Adds Google OAuth login so users can authenticate via their Google account. Flow:

1. Frontend calls `GET /api/v1/auth/oauth/google/` to get the Google authorization URL
2. User authenticates with Google, which redirects back with a `code`
3. Frontend (or redirect) hits `GET /api/v1/auth/oauth/google/callback/?code=...`
4. Backend exchanges the code for user info, creates or links the account, and returns JWT access + refresh tokens

## Key decisions
- New users created via OAuth get `set_unusable_password()` — no plaintext passwords stored
- Existing users with matching email are linked to their Google account automatically
- Follows the project's layered architecture (presentation → business → data)

## Files changed
- `backend/users/business/services.py` — added `OAuthService` class
- `backend/users/data/repositories.py` — added `get_or_create_oauth_user()`
- `backend/users/presentation/views.py` — added `GoogleAuthURLView` and `GoogleCallbackView`
- `backend/users/urls.py` — added OAuth routes
- `backend/users/tests/test_oauth.py` — 5 tests covering auth URL generation, callback handling, new user creation, existing user linking, and invalid code handling

## How to test
cd backend
DJANGO_SETTINGS_MODULE=config.settings_test python -m pytest users/tests/test_oauth.py -v

## Test Results
5/5 passing ✅
- ✅ `test_get_google_auth_url` — Google auth URL generation returns correct URL with client ID
- ✅ `test_callback_missing_code_returns_400` — Missing authorization code returns 400
- ✅ `test_callback_creates_new_user` — New user created automatically on first OAuth login (no password stored)
- ✅ `test_callback_links_existing_user` — Existing user with matching email is linked correctly
- ✅ `test_callback_invalid_code_returns_400` — Invalid/expired authorization code returns 400